### PR TITLE
POC Rewrite bloom filter pruning predicate logic in terms of intervals

### DIFF
--- a/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
@@ -201,7 +201,8 @@ impl BloomFilterPruningPredicate {
 
     /// filter the expr with bloom filter return true if the expr can be pruned
     fn prune(&self, column_sbbf: &HashMap<String, Sbbf>) -> bool {
-        // rewrite any <col = literal> exprs to to `false` if we can provve they are using the bloom filter.
+        // rewrite any <col = literal> exprs to to `false` if we can prove they
+        // are always false using the bloom filter.
         let rewritten = self
             .predicate_expr
             .clone()
@@ -262,59 +263,6 @@ impl BloomFilterPruningPredicate {
 
         is_always_false_interval(interval)
     }
-
-    /*
-            match expr.op() {
-                Operator::And => {
-                    let left = Self::prune_expr_with_bloom_filter(
-                        expr.left().as_any().downcast_ref::<phys_expr::BinaryExpr>(),
-                        column_sbbf,
-                    );
-                    let right = Self::prune_expr_with_bloom_filter(
-                        expr.right()
-                            .as_any()
-                            .downcast_ref::<phys_expr::BinaryExpr>(),
-                        column_sbbf,
-                    );
-                    left || right
-                }
-                Operator::Or => {
-                    let left = Self::prune_expr_with_bloom_filter(
-                        expr.left().as_any().downcast_ref::<phys_expr::BinaryExpr>(),
-                        column_sbbf,
-                    );
-                    let right = Self::prune_expr_with_bloom_filter(
-                        expr.right()
-                            .as_any()
-                            .downcast_ref::<phys_expr::BinaryExpr>(),
-                        column_sbbf,
-                    );
-                    left && right
-                }
-                Operator::Eq => {
-                    if let Some((col, val)) = Self::check_expr_is_col_equal_const(expr) {
-                        if let Some(sbbf) = column_sbbf.get(col.name()) {
-                            match val {
-                                ScalarValue::Utf8(Some(v)) => !sbbf.check(&v.as_str()),
-                                ScalarValue::Boolean(Some(v)) => !sbbf.check(&v),
-                                ScalarValue::Float64(Some(v)) => !sbbf.check(&v),
-                                ScalarValue::Float32(Some(v)) => !sbbf.check(&v),
-                                ScalarValue::Int64(Some(v)) => !sbbf.check(&v),
-                                ScalarValue::Int32(Some(v)) => !sbbf.check(&v),
-                                ScalarValue::Int16(Some(v)) => !sbbf.check(&v),
-                                ScalarValue::Int8(Some(v)) => !sbbf.check(&v),
-                                _ => false,
-                            }
-                        } else {
-                            false
-                        }
-                    } else {
-                        false
-                    }
-                }
-                _ => false,
-            }
-    */
 
     fn get_predicate_columns(expr: &Arc<dyn PhysicalExpr>) -> HashSet<String> {
         let mut columns = HashSet::new();

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -349,7 +349,13 @@ impl PhysicalExpr for BinaryExpr {
             //       upon adding support for additional logical operators, this
             //       method will require modification to support propagating the
             //       changes accordingly.
-            return Ok(vec![]);
+            if matches!(self.op, Operator::And) {
+                return Ok(vec![]);
+            } else if matches!(self.op, Operator::Or) {
+                todo!();
+            } else {
+                unreachable!()
+            }
         } else if self.op.is_comparison_operator() {
             if interval == &Interval::CERTAINLY_FALSE {
                 // TODO: We will handle strictly false clauses by negating


### PR DESCRIPTION
## Which issue does this PR close?

This is related to https://github.com/apache/arrow-datafusion/pull/7821 and the hope of a high level unification of PruningPredicate and the interval arithmetic (I thought there was a ticket, but I can't find it)

## Rationale for this change
Basically DataFusion has two types of range analysis -- the `Interval` based analysis used in selectivity analysis and the `PruningPrediate` based rewrite used for pruning row groups in parquet. 

 https://github.com/apache/arrow-datafusion/pull/7821  adds a `BloomFilterPredicate` in the style of `PruningPredicate`. However, this only supports binary expressions (`col = <const>`) and `AND` / `OR` and is entirely separate from  statistics based pruning. This means that predicates like `col IN (...)` and `IS NOT NULL` may not be completely supported. 

I am pretty sure I could express the same analysis in terms of `Intervals`, which: 
1. Is more general (as we add support for range analysis in predicates, the bloom filtering will support them as well)
2. Is more concise (less code) 
3. and this would serve as a proof of concept for using the Intervals for the more general PredicatePruning. 


## What changes are included in this PR?


1. Express the application of Bloom filters using interval arithmetic rather than partial expression evaluation. 


## Are these changes tested?

Yes, existing tests

## Are there any user-facing changes?

Not really. 