### PR TITLE
Require all zero argument UDFs use `Signature::Nullary`, improve error messages

### DIFF
--- a/datafusion/core/tests/user_defined/user_defined_scalar_functions.rs
+++ b/datafusion/core/tests/user_defined/user_defined_scalar_functions.rs
@@ -270,7 +270,7 @@ async fn scalar_udf_zero_params() -> Result<()> {
 
     let get_100_udf = Simple0ArgsScalarUDF {
         name: "get_100".to_string(),
-        signature: Signature::exact(vec![], Volatility::Immutable),
+        signature: Signature::nullary(Volatility::Immutable),
         return_type: DataType::Int32,
     };
 
@@ -1121,11 +1121,7 @@ async fn create_scalar_function_from_sql_statement() -> Result<()> {
 
 #[tokio::test]
 async fn test_valid_zero_argument_signatures() {
-    let signatures = vec![
-        Signature::exact(vec![], Volatility::Immutable),
-        Signature::any(0, Volatility::Immutable),
-        Signature::nullary(Volatility::Immutable),
-    ];
+    let signatures = vec![Signature::nullary(Volatility::Immutable)];
     for signature in signatures {
         let ctx = SessionContext::new();
         let udf = ScalarFunctionWrapper {
@@ -1161,6 +1157,8 @@ async fn test_invalid_zero_argument_signatures() {
         Signature::uniform(0, vec![], Volatility::Immutable),
         Signature::coercible(vec![], Volatility::Immutable),
         Signature::comparable(0, Volatility::Immutable),
+        Signature::any(0, Volatility::Immutable),
+        Signature::exact(vec![], Volatility::Immutable),
     ];
     for signature in signatures {
         let ctx = SessionContext::new();

--- a/datafusion/expr-common/src/signature.rs
+++ b/datafusion/expr-common/src/signature.rs
@@ -342,8 +342,6 @@ impl TypeSignature {
     /// Check whether 0 input argument is valid for given `TypeSignature`
     pub fn supports_zero_argument(&self) -> bool {
         match &self {
-            TypeSignature::Exact(vec) => vec.is_empty(),
-            TypeSignature::Any(0) => true,
             TypeSignature::Nullary => true,
             TypeSignature::OneOf(types) => types
                 .iter()

--- a/datafusion/expr-common/src/signature.rs
+++ b/datafusion/expr-common/src/signature.rs
@@ -613,47 +613,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn supports_zero_argument_tests() {
-        // Testing `TypeSignature`s which supports 0 arg
-        let positive_cases = vec![
-            TypeSignature::Exact(vec![]),
-            TypeSignature::OneOf(vec![
-                TypeSignature::Exact(vec![DataType::Int8]),
-                TypeSignature::Nullary,
-                TypeSignature::Uniform(1, vec![DataType::Int8]),
-            ]),
-            TypeSignature::Nullary,
-        ];
-
-        for case in positive_cases {
-            assert!(
-                case.supports_zero_argument(),
-                "Expected {:?} to support zero arguments",
-                case
-            );
-        }
-
-        // Testing `TypeSignature`s which doesn't support 0 arg
-        let negative_cases = vec![
-            TypeSignature::Exact(vec![DataType::Utf8]),
-            TypeSignature::Uniform(1, vec![DataType::Float64]),
-            TypeSignature::Any(1),
-            TypeSignature::OneOf(vec![
-                TypeSignature::Exact(vec![DataType::Int8]),
-                TypeSignature::Uniform(1, vec![DataType::Int8]),
-            ]),
-        ];
-
-        for case in negative_cases {
-            assert!(
-                !case.supports_zero_argument(),
-                "Expected {:?} not to support zero arguments",
-                case
-            );
-        }
-    }
-
-    #[test]
     fn type_signature_partial_ord() {
         // Test validates that partial ord is defined for TypeSignature and Signature.
         assert!(TypeSignature::UserDefined < TypeSignature::VariadicAny);

--- a/datafusion/functions/src/string/uuid.rs
+++ b/datafusion/functions/src/string/uuid.rs
@@ -42,7 +42,7 @@ impl Default for UuidFunc {
 impl UuidFunc {
     pub fn new() -> Self {
         Self {
-            signature: Signature::exact(vec![], Volatility::Volatile),
+            signature: Signature::nullary(Volatility::Volatile),
         }
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Targets  https://github.com/apache/datafusion/pull/13871
