### PR TITLE
Pr 14038 suggestion

### DIFF
--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -1584,6 +1584,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr-common",
  "hashbrown 0.14.5",
+ "indexmap",
  "itertools 0.14.0",
 ]
 

--- a/datafusion/physical-expr-common/Cargo.toml
+++ b/datafusion/physical-expr-common/Cargo.toml
@@ -42,3 +42,4 @@ datafusion-common = { workspace = true, default-features = true }
 datafusion-expr-common = { workspace = true }
 hashbrown = { workspace = true }
 itertools = { workspace = true }
+indexmap = { workspace = true }

--- a/datafusion/physical-expr-common/Cargo.toml
+++ b/datafusion/physical-expr-common/Cargo.toml
@@ -41,5 +41,5 @@ arrow = { workspace = true }
 datafusion-common = { workspace = true, default-features = true }
 datafusion-expr-common = { workspace = true }
 hashbrown = { workspace = true }
-itertools = { workspace = true }
 indexmap = { workspace = true }
+itertools = { workspace = true }

--- a/datafusion/physical-expr-common/src/sort_expr.rs
+++ b/datafusion/physical-expr-common/src/sort_expr.rs
@@ -30,7 +30,8 @@ use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 use datafusion_common::Result;
 use datafusion_expr_common::columnar_value::ColumnarValue;
-use itertools::Itertools;
+use itertools::{izip, Itertools};
+use indexmap::IndexSet;
 
 /// Represents Sort operation for a column in a RecordBatch
 ///
@@ -568,10 +569,18 @@ impl LexRequirement {
     /// `vec![a Some(ASC)]`.
     pub fn collapse(self) -> Self {
         let mut output = Vec::<PhysicalSortRequirement>::new();
+        let mut exprs = IndexSet::new();
+        let mut reqs = vec![];
         for item in self {
-            if !output.iter().any(|req| req.expr.eq(&item.expr)) {
-                output.push(item);
+            let PhysicalSortRequirement { expr, options: req } = item;
+            // new insertion
+            if exprs.insert(expr) {
+                reqs.push(req);
             }
+        }
+        debug_assert_eq!(reqs.len(), exprs.len());
+        for (expr, req) in izip!(exprs, reqs) {
+            output.push(PhysicalSortRequirement::new(expr, req));
         }
         LexRequirement::new(output)
     }

--- a/datafusion/physical-expr-common/src/sort_expr.rs
+++ b/datafusion/physical-expr-common/src/sort_expr.rs
@@ -30,8 +30,8 @@ use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 use datafusion_common::Result;
 use datafusion_expr_common::columnar_value::ColumnarValue;
-use itertools::{izip, Itertools};
 use indexmap::IndexSet;
+use itertools::{izip, Itertools};
 
 /// Represents Sort operation for a column in a RecordBatch
 ///


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

As discussed in the [#13748](https://github.com/apache/datafusion/issues/13748), implementation of the `collapse` might be one of the reasons of the slow performance when column number is very large. This PR changes the `collapse` implementation to remove quadratic complexity. 

I couldn't verify, however updated implementation might remedy some part of the problem.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
